### PR TITLE
fix: Fix regex matching any issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ const config = new ConfigStore({
  * @returns {Object}
  */
 function getDocumentData(doc) {
-  const re = /\/(\d{4})\/(\d{2})$/;
+  const re = /\/(\d{4})\/(.{2,})$/g;
   const [, year, issue] = re.exec(doc.filePath);
 
   const validYear = year && !Number.isNaN(Number.parseInt(year, 10));


### PR DESCRIPTION
Earlier the issue part of the regex in getDocumentData only matched tow digit issues. But it needs
to match all types of issues starting with tow digits and maybe continues with additional names
after that (e.g. 01 Hello World, 02-Special Edition)

fix #1